### PR TITLE
Fix previous button in blog pagination

### DIFF
--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -5,7 +5,7 @@
     <ul class="pagination pg-dark justify-content-center">
         <li class="page-item {{if eq $paginator.PageNumber 1 }}disabled{{end}}"><a class="page-link" href="{{$paginator.First.URL}}">First</a></li>
         <li class="page-item {{ if eq $paginator.HasPrev false }}disabled{{end}}">
-            <a class="page-link" aria-label="Previous" {{if eq $paginator.HasNext false}}href="#" {{else}} href="{{$paginator.Next.URL}}" {{end}}>
+            <a class="page-link" aria-label="Previous" {{if eq $paginator.HasPrev false}}href="#" {{else}} href="{{$paginator.Prev.URL}}" {{end}}>
                 <span aria-hidden="true">&laquo;</span>
                 <span class="sr-only">Previous</span>
             </a>


### PR DESCRIPTION
There was a bug in the blog pagination where the previous button actually went to the next page.