### PR TITLE
Add previous/next buttons to single blog page

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -27,6 +27,24 @@
         <div class="row">
             <div class="col-md-12 col-lg-10">
                 {{ .Page.Content }}
+              <ul class="pagination pg-dark justify-content-center">
+              {{if .PrevInSection}}
+                <li class="page-item">
+                  <a class="page-link" aria-label="Previous" href="{{.PrevInSection.Permalink}}">
+                    <span aria-hidden="true">&laquo; {{.PrevInSection.Title}}</span>
+                    <span class="sr-only">Previous</span>
+                  </a>
+                </li>
+              {{end}}
+              {{if .NextInSection}}
+                <li class="page-item">
+                  <a class="page-link" aria-label="Next" href="{{.NextInSection.Permalink}}">
+                    <span aria-hidden="true">{{.NextInSection.Title}} &raquo;</span>
+                    <span class="sr-only">Previous</span>
+                  </a>
+                </li>
+              {{end}}
+              </ul>
             </div>
         </div>
     </div>


### PR DESCRIPTION
I also like it when blogs have links to the previous and next posts. Not entirely sure if current implementation fits the design (not actually a frontender), so feel free to be critical about the current implementation :)